### PR TITLE
Add Direct Install link in header

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -168,13 +168,8 @@ const Header = (props: IProps) => {
                 </a>
               </Link>
               <NavLink>
-                <a href="https://github.com/microsoft/winget-cli/releases">
-                  Install winget
-                </a>
-              </NavLink>
-              <NavLink>
                 <a href="ms-appinstaller:?source=https://aka.ms/getwinget">
-                  Direct Install winget
+                  Install winget
                 </a>
               </NavLink>
               <NavLink>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -173,6 +173,11 @@ const Header = (props: IProps) => {
                 </a>
               </NavLink>
               <NavLink>
+                <a href="ms-appinstaller:?source=https://aka.ms/getwinget">
+                  Direct Install winget
+                </a>
+              </NavLink>
+              <NavLink>
                 <a href="https://github.com/winget-run">GitHub</a>
               </NavLink>
               <NavLink>


### PR DESCRIPTION
There is a link in [official blog](https://devblogs.microsoft.com/commandline/windows-package-manager-1-0/#how-do-i-get-it) for directly installing winget without downloading it first.

It would be nice if users can install it with one click